### PR TITLE
Feat/security

### DIFF
--- a/src/main/java/com/juu/juulabel/admin/AdminController.java
+++ b/src/main/java/com/juu/juulabel/admin/AdminController.java
@@ -9,10 +9,8 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(
     name = "관리자 API",
@@ -35,4 +33,8 @@ public class AdminController {
         return CommonResponse.success(SuccessCode.SUCCESS);
     }
 
+    @GetMapping("/permission/test")
+    public ResponseEntity<Member> test(@AuthenticationPrincipal Member member) {
+        return ResponseEntity.ok(member);
+    }
 }

--- a/src/main/java/com/juu/juulabel/admin/TestAccessTokenController.java
+++ b/src/main/java/com/juu/juulabel/admin/TestAccessTokenController.java
@@ -2,6 +2,8 @@ package com.juu.juulabel.admin;
 
 
 import com.juu.juulabel.common.provider.JwtTokenProvider;
+import com.juu.juulabel.member.domain.Member;
+import com.juu.juulabel.member.service.MemberService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -18,6 +20,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class TestAccessTokenController {
 
     private final JwtTokenProvider jwtTokenProvider;
+    private final MemberService memberService;
 
     @Operation(
             summary = "JWT 테스트용 토큰 발급 API",
@@ -25,7 +28,8 @@ public class TestAccessTokenController {
     )
     @GetMapping("/token")
     public String testAccessToken(@RequestParam(defaultValue = "rldh11111@naver.com") String email) {
-        return jwtTokenProvider.createAccessToken(email);
+        Member member = memberService.getMemberByEmail(email);
+        return jwtTokenProvider.createAccessToken(member);
     }
 
 }

--- a/src/main/java/com/juu/juulabel/common/config/SecurityConfig.java
+++ b/src/main/java/com/juu/juulabel/common/config/SecurityConfig.java
@@ -2,21 +2,21 @@ package com.juu.juulabel.common.config;
 
 import com.juu.juulabel.common.filter.JwtAuthorizationFilter;
 import com.juu.juulabel.common.filter.JwtExceptionFilter;
+import com.juu.juulabel.member.domain.MemberRole;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpHeaders;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
-import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
+import java.util.Arrays;
 import java.util.List;
 
 import static org.springframework.http.HttpMethod.OPTIONS;
@@ -29,58 +29,57 @@ public class SecurityConfig {
     private final JwtExceptionFilter jwtExceptionFilter;
 
     private static final String[] PERMIT_PATHS = {
-        "/swagger-ui/**", "/v3/api-docs/**", "/error", "/favicon.ico", "/", "/actuator/**",
-        "/v1/api/alcohols/**", "/v1/api/terms/**", "/v1/api/images",
-        "/v1/api/members/**", "/v1/api/shared-space/tasting-notes/**", "/v1/api/notifications/**",
-        "/v1/api/daily-lives/**", "/v1/api/alcoholicDrinks/**", "v1/api/follow" , "/**"
+            "/swagger-ui/**", "/v3/api-docs/**", "/error", "/favicon.ico", "/", "/actuator/**",
+            "/v1/api/alcohols/**", "/v1/api/terms/**", "/v1/api/images",
+            "/v1/api/members/**", "/v1/api/shared-space/tasting-notes/**", "/v1/api/notifications/**",
+            "/v1/api/daily-lives/**", "/v1/api/alcoholicDrinks/**", "v1/api/follow",
+            "/**"
     };
 
     private static final String[] ALLOW_ORIGINS = {
-        "http://localhost:8084",
-        "http://localhost:8080",
-        "http://localhost:5173",
-        "http://localhost:3000",
-        "https://api.juulabel.com",
-        "https://qa.juulabel.com",
-        "https://juulabel.com",
-        "https://juulabel.shop",
-        "https://juulabel-front.vercel.app/",
-        "https://juulabel-front-seven.vercel.app/",
-        "https://d3jwyw9rpnxu8p.cloudfront.net"
+            "http://localhost:8084",
+            "http://localhost:8080",
+            "http://localhost:5173",
+            "http://localhost:3000",
+            "https://api.juulabel.com",
+            "https://qa.juulabel.com",
+            "https://juulabel.com",
+            "https://juulabel.shop",
+            "https://juulabel-front.vercel.app/",
+            "https://juulabel-front-seven.vercel.app/",
+            "https://d3jwyw9rpnxu8p.cloudfront.net"
     };
-
-    @Bean
-    public PasswordEncoder passwordEncoder() {
-        return new BCryptPasswordEncoder();
-    }
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         return http
-            .csrf(AbstractHttpConfigurer::disable)
-            .httpBasic(AbstractHttpConfigurer::disable)
-            .cors(cors -> cors.configurationSource(corsConfigurationSource()))
-            .formLogin(AbstractHttpConfigurer::disable)
-            .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .csrf(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .headers(headers -> headers.frameOptions(HeadersConfigurer.FrameOptionsConfig::sameOrigin))
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+                .formLogin(AbstractHttpConfigurer::disable)
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
 
-            .authorizeHttpRequests(authorize -> authorize
-                .requestMatchers("/v1/api/members/logout").authenticated()
-                .requestMatchers(OPTIONS, "**").permitAll()
-                .requestMatchers(PERMIT_PATHS).permitAll()
-                .anyRequest().authenticated()
-            )
+                .authorizeHttpRequests(authorize -> authorize
+                        .requestMatchers("/v1/api/members/logout").authenticated()
+                        .requestMatchers(OPTIONS, "**").permitAll()
+                        .requestMatchers(PERMIT_PATHS).permitAll()
+                        .requestMatchers("/v1/api/admins/permission/test").hasAnyAuthority(MemberRole.ROLE_ADMIN.name())
+                        .anyRequest().authenticated()
+                )
 
-            .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
-            .addFilterBefore(jwtExceptionFilter, JwtAuthorizationFilter.class)
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(jwtExceptionFilter, JwtAuthorizationFilter.class)
 
-            .build();
+                .build();
     }
 
     @Bean
-    CorsConfigurationSource corsConfigurationSource() {
+    public UrlBasedCorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration config = new CorsConfiguration();
         config.addAllowedHeader("*");
         config.addAllowedMethod("*");
+        config.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE"));
         config.setAllowedOrigins(List.of(ALLOW_ORIGINS));
         config.addExposedHeader(HttpHeaders.AUTHORIZATION);
         config.setAllowCredentials(true);

--- a/src/main/java/com/juu/juulabel/common/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/juu/juulabel/common/exception/handler/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.juu.juulabel.common.exception.handler;
 
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 import com.juu.juulabel.common.exception.BaseException;
 import com.juu.juulabel.common.exception.code.ErrorCode;
 import com.juu.juulabel.common.response.CommonResponse;
@@ -8,11 +9,13 @@ import io.jsonwebtoken.MalformedJwtException;
 import io.sentry.Sentry;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.servlet.resource.NoResourceFoundException;
 
+import java.util.Arrays;
 import java.util.Objects;
 
 @Slf4j
@@ -60,8 +63,25 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(NoResourceFoundException.class)
     public void handle(NoResourceFoundException e) {
-    // 이거 키면 출력이 너무 많이 됨
-    //log.warn("NoResourceFoundException : {}", e.getMessage());
+        // 이거 키면 출력이 너무 많이 됨
+        //log.warn("NoResourceFoundException : {}", e.getMessage());
     }
 
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<CommonResponse<String>> handleValidationException(HttpMessageNotReadableException exception) {
+        String errorDetails = "";
+        log.error("HttpMessageNotReadableException :", exception);
+        if (exception.getCause() instanceof InvalidFormatException invalidFormatException) {
+            if (invalidFormatException.getTargetType() != null && invalidFormatException.getTargetType().isEnum()) {
+                errorDetails = String.format("'%s'. 값은 다음 중 하나여야 합니다: %s.",
+                        invalidFormatException.getPath().getLast().getFieldName(),
+                        Arrays.toString(invalidFormatException.getTargetType().getEnumConstants())
+                );
+            }
+        }
+        if (errorDetails.isEmpty()) {
+            errorDetails = exception.getMessage();
+        }
+        return CommonResponse.fail(ErrorCode.VALIDATION_ERROR, errorDetails);
+    }
 }

--- a/src/main/java/com/juu/juulabel/common/provider/JwtTokenProvider.java
+++ b/src/main/java/com/juu/juulabel/common/provider/JwtTokenProvider.java
@@ -1,63 +1,71 @@
 package com.juu.juulabel.common.provider;
 
-import com.juu.juulabel.common.principal.CustomUserDetailsService;
-import com.juu.juulabel.common.principal.JuulabelMember;
 import com.juu.juulabel.common.constants.AuthConstants;
 import com.juu.juulabel.common.exception.CustomJwtException;
 import com.juu.juulabel.common.exception.InvalidParamException;
 import com.juu.juulabel.common.exception.code.ErrorCode;
+import com.juu.juulabel.member.domain.Member;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
 import javax.crypto.SecretKey;
 import java.time.Duration;
-import java.util.Base64;
-import java.util.Date;
-import java.util.Optional;
+import java.util.*;
 
 @Component
 public class JwtTokenProvider {
 
-    public static final Long ACCESS_TOKEN_EXPIRE_TIME = Duration.ofHours(6).toMillis();
+    private static final long ACCESS_TOKEN_EXPIRE_TIME = Duration.ofDays(1).toMillis();
+    private static final String ISSUER = "juulabel";
+    private static final String ROLE_CLAIM = "role";
 
     private final SecretKey key;
-    private final CustomUserDetailsService customUserDetailsService;
 
-    public JwtTokenProvider(
-        @Value("${spring.jwt.secret}") String key,
-        CustomUserDetailsService customUserDetailsService
-    ) {
+    public JwtTokenProvider(@Value("${spring.jwt.secret}") String key) {
         byte[] keyBytes = Base64.getDecoder().decode(key);
         this.key = Keys.hmacShaKeyFor(keyBytes);
-        this.customUserDetailsService = customUserDetailsService;
     }
 
-    public String createAccessToken(String email) {
-        Date now = new Date();
-        long accessTokenExpireTime = now.getTime() + ACCESS_TOKEN_EXPIRE_TIME;
-
+    public String createAccessToken(Member member) {
         return Jwts.builder()
-                .subject(email)
-                .issuedAt(now)
-                .expiration(new Date(accessTokenExpireTime))
+                .subject(String.valueOf(member.getId()))
+                .claim(ROLE_CLAIM, member.getRole().name())
+                .issuedAt(new Date())
+                .issuer(ISSUER)
+                .expiration(new Date(System.currentTimeMillis() + ACCESS_TOKEN_EXPIRE_TIME))
                 .signWith(key)
                 .compact();
     }
 
-    public Authentication getAuthentication(String token) {
-        JuulabelMember userDetails = (JuulabelMember) customUserDetailsService.loadUserByUsername(getEmailByToken(token));
-        return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
+
+    public Authentication getAuthentication(String accessToken) {
+        Claims claims = parseClaims(accessToken);
+
+        Collection<? extends GrantedAuthority> roles =
+                Collections.singletonList(new SimpleGrantedAuthority(claims.get(ROLE_CLAIM, String.class)));
+
+        Member member = Member.builder()
+                .id(Long.parseLong(claims.getSubject()))
+                .build();
+
+        return new UsernamePasswordAuthenticationToken(
+                member,
+                null,
+                roles
+        );
     }
 
     public String resolveToken(String header) {
         return Optional.ofNullable(header)
-            .orElseThrow(() -> new InvalidParamException(ErrorCode.INVALID_AUTHENTICATION))
-            .replace(AuthConstants.TOKEN_PREFIX, "");
+                .orElseThrow(() -> new InvalidParamException(ErrorCode.INVALID_AUTHENTICATION))
+                .replace(AuthConstants.TOKEN_PREFIX, "");
     }
 
     public boolean isValidateToken(String token) {
@@ -66,10 +74,6 @@ public class JwtTokenProvider {
         }
 
         return !getExpirationByToken(token).before(new Date());
-    }
-
-    public String getEmailByToken(String token) {
-        return parseClaims(token).getSubject();
     }
 
     public Date getExpirationByToken(String token) {

--- a/src/main/java/com/juu/juulabel/member/service/MemberService.java
+++ b/src/main/java/com/juu/juulabel/member/service/MemberService.java
@@ -68,6 +68,10 @@ public class MemberService {
     private final MemberJpaRepository memberJpaRepository;
 
 
+    public Member getMemberByEmail(String email) {
+        return memberReader.getByEmail(email);
+    }
+
     @Transactional
     public LoginResponse login(OAuthLoginRequest oAuthLoginRequest) {
         OAuthLoginInfo authLoginInfo = oAuthLoginRequest.toDto();
@@ -89,8 +93,13 @@ public class MemberService {
 
         validateNotWithdrawnMember(email);
 
-        Token token = createTokenForMember(isNewMember, email); // TODO : 카카오와 구글 이메일이 같다면 토큰 중복 사용 가능 여부 확인
-
+        String generatedToken = jwtTokenProvider.createAccessToken(getMemberByEmail(email));
+        Token token;
+        if (isNewMember) {
+            token = new Token(null, null);
+        }else{
+            token = new Token(generatedToken, jwtTokenProvider.getExpirationByToken(generatedToken));
+        }
         return new LoginResponse(
                 token,
                 isNewMember,
@@ -120,7 +129,7 @@ public class MemberService {
             memberTermsWriter.storeAll(memberTerms);
         }
 
-        String token = jwtTokenProvider.createAccessToken(member.getEmail());
+        String token = jwtTokenProvider.createAccessToken(member);
 
         return new SignUpMemberResponse(
                 member.getId(),
@@ -128,14 +137,6 @@ public class MemberService {
         );
     }
 
-    private Token createTokenForMember(boolean isNewMember, String email) {
-        if (isNewMember) {
-            return new Token(null, null);
-        } else {
-            String generatedToken = jwtTokenProvider.createAccessToken(email);
-            return new Token(generatedToken, jwtTokenProvider.getExpirationByToken(generatedToken));
-        }
-    }
 
     private List<MemberAlcoholType> getMemberAlcoholTypeList(Member member, List<Long> alcoholTypeIdList) {
         return alcoholTypeIdList.stream()

--- a/src/main/java/com/juu/juulabel/member/service/MemberService.java
+++ b/src/main/java/com/juu/juulabel/member/service/MemberService.java
@@ -9,6 +9,7 @@ import com.juu.juulabel.alcohol.response.AlcoholicDrinksSummary;
 import com.juu.juulabel.common.constants.AuthConstants;
 import com.juu.juulabel.common.dto.request.*;
 import com.juu.juulabel.common.dto.response.*;
+import com.juu.juulabel.common.exception.BaseException;
 import com.juu.juulabel.common.exception.InvalidParamException;
 import com.juu.juulabel.common.exception.code.ErrorCode;
 import com.juu.juulabel.common.factory.OAuthProviderFactory;
@@ -20,6 +21,7 @@ import com.juu.juulabel.dailylife.response.MyDailyLifeSummary;
 import com.juu.juulabel.follow.repository.FollowReader;
 import com.juu.juulabel.member.domain.*;
 import com.juu.juulabel.member.repository.*;
+import com.juu.juulabel.member.repository.jpa.MemberJpaRepository;
 import com.juu.juulabel.member.request.OAuthLoginInfo;
 import com.juu.juulabel.member.request.OAuthUser;
 import com.juu.juulabel.member.request.OAuthUserInfo;
@@ -63,6 +65,7 @@ public class MemberService {
     private final WithdrawalRecordWriter withdrawalRecordWriter;
     private final WithdrawalRecordReader withdrawalRecordReader;
     private final FollowReader followReader;
+    private final MemberJpaRepository memberJpaRepository;
 
 
     @Transactional
@@ -72,9 +75,9 @@ public class MemberService {
 
         // 인가 코드를 이용해 토큰 발급 요청
         String accessToken = providerFactory.getAccessToken(
-            provider,
-            authLoginInfo.propertyMap().get(AuthConstants.REDIRECT_URI),
-            authLoginInfo.propertyMap().get(AuthConstants.CODE)
+                provider,
+                authLoginInfo.propertyMap().get(AuthConstants.REDIRECT_URI),
+                authLoginInfo.propertyMap().get(AuthConstants.CODE)
         );
 
         // 토큰을 이용해 사용자 정보 가져오기
@@ -89,9 +92,9 @@ public class MemberService {
         Token token = createTokenForMember(isNewMember, email); // TODO : 카카오와 구글 이메일이 같다면 토큰 중복 사용 가능 여부 확인
 
         return new LoginResponse(
-            token,
-            isNewMember,
-            new OAuthUserInfo(email, oAuthUser.id(), provider)
+                token,
+                isNewMember,
+                new OAuthUserInfo(email, oAuthUser.id(), provider)
         );
     }
 
@@ -105,14 +108,14 @@ public class MemberService {
 
         // 선호전통주 주종 등록
         List<MemberAlcoholType> memberAlcoholTypeList =
-            getMemberAlcoholTypeList(member, signUpRequest.alcoholTypeIds());
+                getMemberAlcoholTypeList(member, signUpRequest.alcoholTypeIds());
         if (!memberAlcoholTypeList.isEmpty()) {
             memberAlcoholTypeWriter.storeAll(memberAlcoholTypeList);
         }
 
         // 약관 등록
         List<MemberTerms> memberTerms =
-            getAndValidateTermsWithMapping(member, signUpRequest.termsAgreements());
+                getAndValidateTermsWithMapping(member, signUpRequest.termsAgreements());
         if (!memberTerms.isEmpty()) {
             memberTermsWriter.storeAll(memberTerms);
         }
@@ -120,8 +123,8 @@ public class MemberService {
         String token = jwtTokenProvider.createAccessToken(member.getEmail());
 
         return new SignUpMemberResponse(
-            member.getId(),
-            new Token(token, jwtTokenProvider.getExpirationByToken(token))
+                member.getId(),
+                new Token(token, jwtTokenProvider.getExpirationByToken(token))
         );
     }
 
@@ -136,11 +139,11 @@ public class MemberService {
 
     private List<MemberAlcoholType> getMemberAlcoholTypeList(Member member, List<Long> alcoholTypeIdList) {
         return alcoholTypeIdList.stream()
-            .map(alcoholTypeId -> {
-                AlcoholType alcoholType = alcoholTypeReader.getById(alcoholTypeId);
-                return MemberAlcoholType.create(member, alcoholType);
-            })
-            .toList();
+                .map(alcoholTypeId -> {
+                    AlcoholType alcoholType = alcoholTypeReader.getById(alcoholTypeId);
+                    return MemberAlcoholType.create(member, alcoholType);
+                })
+                .toList();
     }
 
     private List<MemberTerms> getAndValidateTermsWithMapping(Member member, List<TermsAgreement> termsAgreements) {
@@ -165,9 +168,9 @@ public class MemberService {
 
         usedTermsList.forEach(terms -> {
             TermsAgreement termsAgreement = termsAgreements.stream()
-                .filter(agreement -> agreement.termsId().equals(terms.getId()))
-                .findFirst()
-                .orElseThrow(() -> new InvalidParamException(ErrorCode.NOT_FOUND_TERMS));
+                    .filter(agreement -> agreement.termsId().equals(terms.getId()))
+                    .findFirst()
+                    .orElseThrow(() -> new InvalidParamException(ErrorCode.NOT_FOUND_TERMS));
 
             final boolean isAgreed = termsAgreement.isAgreed();
 
@@ -210,7 +213,7 @@ public class MemberService {
     @Transactional(readOnly = true)
     public MyDailyLifeListResponse loadMyDailyLifeList(Member member, DailyLifeListRequest request) {
         Slice<MyDailyLifeSummary> myDailyLifeList =
-            dailyLifeReader.getAllMyDailyLives(member, request.lastDailyLifeId(), request.pageSize());
+                dailyLifeReader.getAllMyDailyLives(member, request.lastDailyLifeId(), request.pageSize());
 
         return new MyDailyLifeListResponse(myDailyLifeList);
     }
@@ -218,7 +221,7 @@ public class MemberService {
     @Transactional(readOnly = true)
     public MyTastingNoteListResponse loadMyTastingNoteList(Member member, TastingNoteListRequest request) {
         Slice<MyTastingNoteSummary> myTastingNoteList =
-            tastingNoteReader.getAllMyTastingNotes(member, request.lastTastingNoteId(), request.pageSize());
+                tastingNoteReader.getAllMyTastingNotes(member, request.lastTastingNoteId(), request.pageSize());
 
         return new MyTastingNoteListResponse(myTastingNoteList);
     }
@@ -227,24 +230,24 @@ public class MemberService {
     public boolean saveAlcoholicDrinks(Member member, Long alcoholicDrinksId) {
         AlcoholicDrinks alcoholicDrinks = alcoholicDrinksReader.getById(alcoholicDrinksId);
         Optional<MemberAlcoholicDrinks> memberAlcoholicDrinks =
-            memberAlcoholicDrinksReader.findByMemberAndAlcoholicDrinks(member, alcoholicDrinks);
+                memberAlcoholicDrinksReader.findByMemberAndAlcoholicDrinks(member, alcoholicDrinks);
 
         // 전통주가 이미 저장되어 있다면 삭제, 저장되어 있지 않다면 등록
         return memberAlcoholicDrinks
-            .map(save -> {
-                memberAlcoholicDrinksWriter.delete(save);
-                return false;
-            })
-            .orElseGet(() -> {
-                memberAlcoholicDrinksWriter.store(member, alcoholicDrinks);
-                return true;
-            });
+                .map(save -> {
+                    memberAlcoholicDrinksWriter.delete(save);
+                    return false;
+                })
+                .orElseGet(() -> {
+                    memberAlcoholicDrinksWriter.store(member, alcoholicDrinks);
+                    return true;
+                });
     }
 
     @Transactional(readOnly = true)
     public MyAlcoholicDrinksListResponse loadMyAlcoholicDrinks(Member member, MyAlcoholicDrinksListRequest request) {
         Slice<AlcoholicDrinksSummary> alcoholicDrinksSummaries =
-            alcoholicDrinksReader.getAllMyAlcoholicDrinks(member, request.lastAlcoholicDrinksId(), request.pageSize());
+                alcoholicDrinksReader.getAllMyAlcoholicDrinks(member, request.lastAlcoholicDrinksId(), request.pageSize());
 
         return new MyAlcoholicDrinksListResponse(alcoholicDrinksSummaries);
     }
@@ -257,16 +260,16 @@ public class MemberService {
         long followerCount = followReader.countFollower(member);
 
         return new MySpaceResponse(
-            member.getId(),
-            member.getProfileImage(),
-            member.getNickname(),
-            member.getIntroduction(),
-            member.isHasBadge(),
-            tastingNoteCount,
-            dailyLifeCount,
-            followingCount,
-            followerCount,
-            0 // TODO : 시음노트 저장 기능 추가 시 수정 필요
+                member.getId(),
+                member.getProfileImage(),
+                member.getNickname(),
+                member.getIntroduction(),
+                member.isHasBadge(),
+                tastingNoteCount,
+                dailyLifeCount,
+                followingCount,
+                followerCount,
+                0 // TODO : 시음노트 저장 기능 추가 시 수정 필요
         );
     }
 
@@ -274,22 +277,22 @@ public class MemberService {
     public MyInfoResponse getMyInfo(Member member) {
         List<Long> alcoholTypeIdList = memberAlcoholTypeReader.getIdListByMember(member);
         return new MyInfoResponse(
-            member.getId(),
-            member.getNickname(),
-            member.getEmail(),
-            member.isHasBadge(),
-            member.isNotificationsAllowed(),
-            member.getIntroduction(),
-            member.getProfileImage(),
-            member.getGender(),
-            alcoholTypeIdList
+                member.getId(),
+                member.getNickname(),
+                member.getEmail(),
+                member.isHasBadge(),
+                member.isNotificationsAllowed(),
+                member.getIntroduction(),
+                member.getProfileImage(),
+                member.getGender(),
+                alcoholTypeIdList
         );
     }
 
     @Transactional(readOnly = true)
     public DailyLifeListResponse loadMemberDailyLifeList(Member loginMember, DailyLifeListRequest request, Long memberId) {
         Slice<DailyLifeSummary> dailyLifeList =
-            dailyLifeReader.getAllDailyLivesByMember(loginMember, memberId, request.lastDailyLifeId(), request.pageSize());
+                dailyLifeReader.getAllDailyLivesByMember(loginMember, memberId, request.lastDailyLifeId(), request.pageSize());
 
         return new DailyLifeListResponse(dailyLifeList);
     }
@@ -298,7 +301,7 @@ public class MemberService {
     public TastingNoteListResponse loadMemberTastingNoteList(Member loginMember, TastingNoteListRequest request, Long memberId) {
         // TODO : 해당 회원(loginMember) 차단 여부 검증 로직
         Slice<TastingNoteSummary> tastingNoteList =
-            tastingNoteReader.getAllTastingNotesByMember(loginMember, memberId, request.lastTastingNoteId(), request.pageSize());
+                tastingNoteReader.getAllTastingNotesByMember(loginMember, memberId, request.lastTastingNoteId(), request.pageSize());
 
         return new TastingNoteListResponse(tastingNoteList);
     }
@@ -314,15 +317,15 @@ public class MemberService {
         boolean isFollowing = followReader.isFollowing(loginMember, member);
 
         return new MemberProfileResponse(
-            member.getId(),
-            member.getNickname(),
-            member.getProfileImage(),
-            member.getIntroduction(),
-            member.isHasBadge(),
-            tastingNoteCount,
-            dailyLifeCount,
-            followingCount,
-            followerCount,
+                member.getId(),
+                member.getNickname(),
+                member.getProfileImage(),
+                member.getIntroduction(),
+                member.isHasBadge(),
+                tastingNoteCount,
+                dailyLifeCount,
+                followingCount,
+                followerCount,
                 isFollowing
         );
     }
@@ -349,8 +352,14 @@ public class MemberService {
     public void deleteAccount(Member loginMember, WithdrawalRequest request) {
         loginMember.deleteAccount();
         withdrawalRecordWriter.store(
-            WithdrawalRecord.create(request.withdrawalReason(), loginMember.getEmail(), loginMember.getNickname())
+                WithdrawalRecord.create(request.withdrawalReason(), loginMember.getEmail(), loginMember.getNickname())
         );
+    }
+
+    @Transactional(readOnly = true)
+    public Member findById(Long memberId) {
+        return memberJpaRepository.findById(memberId)
+                .orElseThrow(() -> new BaseException(ErrorCode.NOT_FOUND_MEMBER));
     }
 }
 

--- a/src/main/java/com/juu/juulabel/report/Report.java
+++ b/src/main/java/com/juu/juulabel/report/Report.java
@@ -1,0 +1,48 @@
+package com.juu.juulabel.report;
+
+import com.juu.juulabel.common.base.BaseTimeEntity;
+import com.juu.juulabel.member.domain.Member;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Entity
+@Table(name = "report")
+public class Report extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "report_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "reporter_id", nullable = false)
+    private Member reporter;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "reported_user_id", nullable = false)
+    private Member reportedUser;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "reviewer")
+    private Member reviewer;
+
+    @Column(name = "reason", nullable = false, length = 255)
+    private String reason;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "type", nullable = false)
+    private ReportType type;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    private ReportStatus status;
+
+    @Column(name = "reviewed_at")
+    private LocalDateTime reviewedAt;
+}

--- a/src/main/java/com/juu/juulabel/report/ReportController.java
+++ b/src/main/java/com/juu/juulabel/report/ReportController.java
@@ -1,0 +1,28 @@
+package com.juu.juulabel.report;
+
+import com.juu.juulabel.common.annotation.LoginMember;
+import com.juu.juulabel.common.exception.code.SuccessCode;
+import com.juu.juulabel.common.response.CommonResponse;
+import com.juu.juulabel.member.domain.Member;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "신고 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/api/reports")
+public class ReportController {
+    private final ReportService reportService;
+
+    @PostMapping
+    public ResponseEntity<CommonResponse<Object>> createReport(
+            @Parameter(hidden = true) @LoginMember Member member,
+            @Valid @RequestBody ReportCreateRequest request) {
+        reportService.createReport(member.getId(), request);
+        return CommonResponse.success(SuccessCode.SUCCESS_INSERT);
+    }
+}

--- a/src/main/java/com/juu/juulabel/report/ReportCreateRequest.java
+++ b/src/main/java/com/juu/juulabel/report/ReportCreateRequest.java
@@ -1,0 +1,18 @@
+package com.juu.juulabel.report;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+
+public record ReportCreateRequest(
+        @NotNull(message = "신고 대상을 넣어주세요")
+        @Min(value = 1, message = "ID는 1 이상이어야 합니다.")
+        Long reportedUserId,
+
+        @NotBlank(message = "신고 사유를 넣어주세요.")
+        String reason,
+
+        ReportType type
+) {
+}

--- a/src/main/java/com/juu/juulabel/report/ReportRepository.java
+++ b/src/main/java/com/juu/juulabel/report/ReportRepository.java
@@ -1,0 +1,6 @@
+package com.juu.juulabel.report;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReportRepository extends JpaRepository<Report, Long> {
+}

--- a/src/main/java/com/juu/juulabel/report/ReportService.java
+++ b/src/main/java/com/juu/juulabel/report/ReportService.java
@@ -1,0 +1,31 @@
+package com.juu.juulabel.report;
+
+import com.juu.juulabel.member.domain.Member;
+import com.juu.juulabel.member.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ReportService {
+
+    private final ReportRepository reportRepository;
+    private final MemberService MemberService;
+
+    @Transactional
+    public void createReport(Long reporterId, ReportCreateRequest request) {
+        Member reporter = MemberService.findById(reporterId);
+        Member reportedUser = MemberService.findById(request.reportedUserId());
+
+        Report report = Report.builder()
+                .reporter(reporter)
+                .reportedUser(reportedUser)
+                .reason(request.reason())
+                .type(request.type())
+                .status(ReportStatus.PENDING)
+                .build();
+
+        reportRepository.save(report);
+    }
+}

--- a/src/main/java/com/juu/juulabel/report/ReportStatus.java
+++ b/src/main/java/com/juu/juulabel/report/ReportStatus.java
@@ -1,0 +1,5 @@
+package com.juu.juulabel.report;
+
+public enum ReportStatus {
+    PENDING, REVIEWING, REJECTED, APPROVED
+}

--- a/src/main/java/com/juu/juulabel/report/ReportStatus.java
+++ b/src/main/java/com/juu/juulabel/report/ReportStatus.java
@@ -1,5 +1,13 @@
 package com.juu.juulabel.report;
 
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
 public enum ReportStatus {
-    PENDING, REVIEWING, REJECTED, APPROVED
+    PENDING("대기중"),
+    REVIEWING("검토중"),
+    REJECTED("거절"),
+    APPROVED("승인");
+
+    private final String description;
 }

--- a/src/main/java/com/juu/juulabel/report/ReportType.java
+++ b/src/main/java/com/juu/juulabel/report/ReportType.java
@@ -1,0 +1,5 @@
+package com.juu.juulabel.report;
+
+public enum ReportType {
+    USER, TASTING_NOTE, DAILY_LIFE, COMMENT
+}

--- a/src/main/java/com/juu/juulabel/report/ReportType.java
+++ b/src/main/java/com/juu/juulabel/report/ReportType.java
@@ -1,5 +1,13 @@
 package com.juu.juulabel.report;
 
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
 public enum ReportType {
-    USER, TASTING_NOTE, DAILY_LIFE, COMMENT
+    USER("유저"),
+    TASTING_NOTE("시음노트"),
+    DAILY_LIFE("일상생활"),
+    COMMENT("댓글");
+
+    private final String description;
 }


### PR DESCRIPTION
## 작업
JWT 로직 수정

기존의 경우 loadUserByUsername을 요청마다 DB 호출

변경: loadUserByUsername 호출을 하지 않음
jwt subject에 email대신 MemberId를 넣음
claim에는 member의 권한을 넣음

아래와 같은 스프링 시큐리티에서 기본으로 제공하는 어노테이션을 사용해 Member의 정보를 가져올 수 있음
![image](https://github.com/user-attachments/assets/7facbe6c-63ae-4879-bc6b-216ccf302d26)


현재는 member의 id, role 권한만 불러오도록 처리
![image](https://github.com/user-attachments/assets/a9403cdd-c3a7-45e2-8da6-29ea7b210418)


**나중에 어드민 추가되면 해야하는 것**
1. 현재 @LoginMember로 되어있는 로직을 @AuthenticationPrinciple로 변경
2. Admin API는 시큐리티에서 권한 처리해야함 현재는 테스트만 해봄, 정상적으로 403에러로 forbidden처리됨
![image](https://github.com/user-attachments/assets/e22bdabd-8f97-4c22-9ed2-2a9ab453e445)
3. 403 에러는 커스텀해서 처리해줘야함
4. 화이트리스트 권한 처리, 현재는 모든 API가 열려있음, 로그인 X, 로그인 O, 어드민 권한 3가지로 구분해야함
![image](https://github.com/user-attachments/assets/02c7ccd4-29b0-4f96-ba79-1b26a946a3a7)
5. 리프레시 토큰 도입, 우선 유저 기능 먼저 개발하고, 시간 남을 때 어떻게 처리할 지 협의 후 제가 백엔드, 프론트 , 앱 설정하겠습니다



