### PR TITLE
FCM 푸시 알림

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ configurations {
 
 repositories {
 	mavenCentral()
+	maven { url 'https://jitpack.io' }
 }
 
 
@@ -87,6 +88,11 @@ dependencies {
 
 	//Sentry
 	implementation 'io.sentry:sentry-spring-boot-starter-jakarta:8.5.0'
+
+
+	//expo fcm push notification
+	implementation 'com.github.hlspablo:expo-server-sdk-java:v3.1.2'
+
 }
 
 def generatedQueryDsl = 'src/main/generated'

--- a/src/main/java/com/juu/juulabel/push_notification/NotificationPushToken.java
+++ b/src/main/java/com/juu/juulabel/push_notification/NotificationPushToken.java
@@ -17,21 +17,21 @@ public class NotificationPushToken extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "id", columnDefinition = "comment '푸시 토큰 고유 번호'")
+    @Column(name = "id")
     private Long id;
 
-    @Column(name = "member_id", nullable = false, columnDefinition = "comment '회원 고유 번호'")
+    @Column(name = "member_id", nullable = false)
     private Long memberId;
 
-    @Column(name = "push_token", columnDefinition = "comment '푸시 토큰'")
+    @Column(name = "push_token")
     private String pushToken;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "platform", columnDefinition = "comment '플랫폼'")
+    @Column(name = "platform")
     private Platform platform;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "permission_status", columnDefinition = "comment '푸시 알림 권한 상태'")
+    @Column(name = "permission_status")
     private PermissionStatus permissionStatus;
 
     public String getPushToken() {

--- a/src/main/java/com/juu/juulabel/push_notification/NotificationPushToken.java
+++ b/src/main/java/com/juu/juulabel/push_notification/NotificationPushToken.java
@@ -1,0 +1,42 @@
+package com.juu.juulabel.push_notification;
+
+
+import com.juu.juulabel.common.base.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Entity
+@Table(
+        name = "notification_push_token"
+)
+public class NotificationPushToken extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", columnDefinition = "comment '푸시 토큰 고유 번호'")
+    private Long id;
+
+    @Column(name = "member_id", nullable = false, columnDefinition = "comment '회원 고유 번호'")
+    private Long memberId;
+
+    @Column(name = "push_token", columnDefinition = "comment '푸시 토큰'")
+    private String pushToken;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "platform", columnDefinition = "comment '플랫폼'")
+    private Platform platform;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "permission_status", columnDefinition = "comment '푸시 알림 권한 상태'")
+    private PermissionStatus permissionStatus;
+
+    public String getPushToken() {
+        return String.format("ExponentPushToken[%s]", pushToken);
+    }
+}
+
+

--- a/src/main/java/com/juu/juulabel/push_notification/NotificationPushTokenController.java
+++ b/src/main/java/com/juu/juulabel/push_notification/NotificationPushTokenController.java
@@ -1,0 +1,31 @@
+package com.juu.juulabel.push_notification;
+
+import com.juu.juulabel.common.exception.code.SuccessCode;
+import com.juu.juulabel.common.response.CommonResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(
+        name = "알림 푸시 토큰 API",
+        description = "알림 푸시 토큰 관련 API"
+)
+@RestController
+@RequestMapping(value = {"/v1/api/notifications/push-tokens"})
+@RequiredArgsConstructor
+public class NotificationPushTokenController {
+
+    @Operation(
+            summary = "유저 푸시 토큰 등록 및 업데이트",
+            description = "푸시 알림을 위한 유저 푸시 토큰 등록 및 업데이트"
+    )
+    @PostMapping("/")
+    public ResponseEntity  <CommonResponse<Void>> registerPushToken(
+    ) {
+        return CommonResponse.success(SuccessCode.SUCCESS);
+    }
+}

--- a/src/main/java/com/juu/juulabel/push_notification/NotificationPushTokenService.java
+++ b/src/main/java/com/juu/juulabel/push_notification/NotificationPushTokenService.java
@@ -1,0 +1,9 @@
+package com.juu.juulabel.push_notification;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationPushTokenService {
+}

--- a/src/main/java/com/juu/juulabel/push_notification/PermissionStatus.java
+++ b/src/main/java/com/juu/juulabel/push_notification/PermissionStatus.java
@@ -1,0 +1,5 @@
+package com.juu.juulabel.push_notification;
+
+public enum PermissionStatus {
+    ALLOW, DENY
+}

--- a/src/main/java/com/juu/juulabel/push_notification/Platform.java
+++ b/src/main/java/com/juu/juulabel/push_notification/Platform.java
@@ -1,0 +1,5 @@
+package com.juu.juulabel.push_notification;
+
+public enum Platform {
+    ANDROID, IOS
+}


### PR DESCRIPTION
## 작업
FCM 푸시 알림 개발 중

React Native Expo Notifiaction을 사용

**푸시 알림 테스트용 사이트**
https://expo.dev/notifications

**expo notification sdk**
https://github.com/hlspablo/expo-server-sdk-java




**고려해야하는 사항**
1. 한 사용자가 한 계정으로 여러 기기에서 동시에 사용
2. 한 기기에서 여러 계정 사용
3. 한 사용자가 오랫동안 사용하지않음
4. 이외의 예기치 않은 FCM 토큰 오류

[참고] : https://tioon.tistory.com/197


**Expo Notification에서 발생하는 에러 종류(공식문서)**
[참고]: https://docs.expo.dev/push-notifications/sending-notifications/#request-errors


Request errors
If there's an error with the entire request for either push tickets or push receipts, the errors object might have one of the following values, and you should handle these errors:

TOO_MANY_REQUESTS: You are exceeding the request limit of 600 notifications per second per project. We recommend implementing rate-limiting in your server to prevent sending more than 600 notifications per second (note that if you use [expo-server-sdk-node](https://github.com/expo/expo-server-sdk-node), this is already implemented along with exponential backoffs for retries).

PUSH_TOO_MANY_EXPERIENCE_IDS: You are trying to send push notifications to different Expo experiences, for example, @username/projectAAA and @username/projectBBB. Check the details field for a mapping of experience names to their associated push tokens from the request, and remove any from another experience.

PUSH_TOO_MANY_NOTIFICATIONS: You are trying to send more than 100 push notifications in one request. Make sure you are only sending 100 (or fewer) notifications in each request.

PUSH_TOO_MANY_RECEIPTS: You are trying to get more than 1000 push receipts in one request. Make sure you are only sending an array of 1000 (or fewer) ticket ID strings to get your push receipts.


